### PR TITLE
add `version` command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 # Command Reference for airfoil
 
-`new (n)`
+## `new (n)`
 
 Create a new React Native project
 
@@ -21,6 +21,27 @@ airfoil new starshipLaunchApp
 ```
 
 Violá! Once everything finishes, you will have a working React Native app ready for development.
+
+---
+
+## `version (v)`
+
+Bump the version number for a React Native project.
+
+This updates the version in `package.json` as well as `ios/` and `android/` directories.
+
+**Example:**
+
+```
+# bump version number (patch release e.g. 0.0.1 -> 0.0.2)
+airfoil version patch
+
+# bump version number (minor release e.g. 0.0.2 -> 0.1.0)
+airfoil version minor
+
+# bump version number (major release e.g. 0.1.0 -> 1.0.0)
+airfoil version major
+```
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,6 @@ async function run(argv) {
     .src(__dirname)
     .plugins('./node_modules', { matching: 'airfoil-*', hidden: true })
     .help() // provides default for help, h, --help, -h
-    .version() // provides default for version, v, --version, -v
     .create();
   // enable the following method if you'd like to skip loading one of these core extensions
   // this can improve performance if they're not necessary for your project:

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,25 +1,28 @@
-
-import { GluegunToolbox } from 'gluegun'
-  
+import { GluegunToolbox } from 'gluegun';
+import { interfaceHelpers } from '../utils/interface';
 
 module.exports = {
   name: 'generate',
-  alias: ['g'],
+  alias: ['g', 'add'],
   run: async (toolbox: GluegunToolbox) => {
     const {
       parameters,
       template: { generate },
       print: { info },
-    } = toolbox
+    } = toolbox;
+    const { titleSecondary, about } = interfaceHelpers(toolbox);
 
-    const name = parameters.first
+    titleSecondary();
+    about();
+
+    const name = parameters.first;
 
     await generate({
       template: 'model.ts.ejs',
       target: `models/${name}-model.ts`,
       props: { name },
-    })
+    });
 
-    info(`Generated file at models/${name}-model.ts`)
+    info(`Generated file at models/${name}-model.ts`);
   },
-}
+};

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,0 +1,93 @@
+import { GluegunToolbox } from 'gluegun';
+import { interfaceHelpers } from '../utils/interface';
+import { validations } from '../utils/validations';
+
+const VERSION_TYPE_MAJOR = 'major';
+const VERSION_TYPE_MINOR = 'minor';
+const VERSION_TYPE_PATCH = 'patch';
+
+const command = {
+  name: 'version',
+  alias: ['v'],
+  run: async (toolbox: GluegunToolbox) => {
+    const { titleSecondary, about, loadWhile } = interfaceHelpers(toolbox);
+    const { checkCurrentDirReactNativeProject } = validations(toolbox);
+
+    titleSecondary();
+    about();
+
+    await loadWhile(checkCurrentDirReactNativeProject());
+
+    updateVersion(toolbox);
+  },
+};
+
+const updateVersion = async (toolbox: GluegunToolbox) => {
+  const { parameters, print } = toolbox;
+  const { gray, cyan, yellow, red, green } = print.colors;
+  const { cmd, printTask, loadWhile } = interfaceHelpers(toolbox);
+
+  const type = parameters.first;
+  if (!type || ![VERSION_TYPE_MAJOR, VERSION_TYPE_MINOR, VERSION_TYPE_PATCH].includes(type)) {
+    printInvalidVersionArgs(toolbox);
+    process.exit(1);
+  }
+
+  let typeColor = cyan;
+  if (type === VERSION_TYPE_MINOR) typeColor = yellow;
+  if (type === VERSION_TYPE_MAJOR) typeColor = red;
+
+  const pkgJsonProps: string = await loadWhile(cmd('cat package.json | npx json version name'));
+  const [currentVersion, appName] = pkgJsonProps.split(/\n/).filter(w => !!w);
+  print.info(gray(`App: ${appName.replace('\n', '')}`));
+  print.info(gray(`Current version: ${currentVersion.replace('\n', '')}`));
+  print.info(gray(`Version change: ${typeColor(`${type} release`)}`));
+  print.newline();
+
+  let task;
+  task = printTask('🔬 Checking some things...');
+  const gitStatus = await cmd('git status');
+  if (!/nothing to commit, working tree clean/.test(gitStatus)) {
+    print.error('\nGit working directory is not clean!');
+    print.error('Commit your work first and then try this command again.');
+    print.newline();
+    process.exit(1);
+  }
+  task.stop();
+
+  // update package.json, ios, android version
+  // see: https://docs.npmjs.com/cli/v6/commands/npm-version
+  // see: https://www.npmjs.com/package/react-native-version
+  task = printTask('🍳 Cooking version number...');
+  await cmd(`npm --no-git-tag-version version ${type}`);
+  const newVersionRaw = await cmd('cat package.json | npx json version');
+  const newVersion = newVersionRaw.replace('\n', '');
+  await cmd(`npx react-native-version --skip-tag --never-amend`);
+  task.stop();
+
+  print.newline();
+  print.info(gray(`New version: ${green(newVersion)}`));
+  print.newline();
+
+  task = printTask('🎓 Graduating to Git...');
+  await cmd(`git tag -a v${newVersion} -m "v${newVersion}"`);
+  await cmd(`git add --all`);
+  await cmd(`git commit -m "bump version to ${newVersion}"`);
+  task.stop();
+
+  print.newline();
+  print.success(`${print.checkmark} All done!`);
+};
+
+const printInvalidVersionArgs = (toolbox: GluegunToolbox) => {
+  const { print } = toolbox;
+  const { gray, cyan } = print.colors;
+  print.error(
+    `\`airfoil update version <type>\` expects type to be one of [${VERSION_TYPE_MAJOR}|${VERSION_TYPE_MINOR}|${VERSION_TYPE_PATCH}]`,
+  );
+  print.info(
+    gray(`If you are trying to print the airfoil version number, run \`${cyan('airfoil help')}\``),
+  );
+};
+
+module.exports = command;

--- a/src/utils/interface.ts
+++ b/src/utils/interface.ts
@@ -7,7 +7,7 @@ import { Toolbox } from 'gluegun/build/types/domain/toolbox';
  * @param toolbox
  */
 export const interfaceHelpers = (toolbox: Toolbox) => {
-  const { print, parameters, system, meta } = toolbox;
+  const { print, parameters, system, meta, commandName } = toolbox;
   const { red, gray, cyan, bgBlack } = print.colors;
 
   const code = (msg: string = '') => {
@@ -24,6 +24,18 @@ export const interfaceHelpers = (toolbox: Toolbox) => {
     print.info(red('███████ ██ ██████  █████   ██    ██ ██ ██      '));
     print.info(red('██   ██ ██ ██   ██ ██      ██    ██ ██ ██      '));
     print.info(red('██   ██ ██ ██   ██ ██       ██████  ██ ███████ '));
+    print.newline();
+  };
+
+  const titleSecondary = () => {
+    print.newline();
+    const spaceLetters = (w = '') => w.split('').join(' ');
+    const str1 = spaceLetters('AIRFOIL');
+    const str2 = spaceLetters(commandName.toUpperCase());
+    const str = red(` ${str1} ${cyan(str2)} `);
+    const len = Math.max(36 - str1.length - str2.length, 0);
+    const ws = ' '.repeat(Math.floor(len / 2));
+    print.info(gray(`--[${ws}${str} ${ws}]--`));
     print.newline();
   };
 
@@ -63,11 +75,12 @@ export const interfaceHelpers = (toolbox: Toolbox) => {
     };
   };
 
-  const loadWhile = async (p: Promise<void> | (() => Promise<void>)) => {
+  const loadWhile = async (p: Promise<any> | (() => Promise<any>)) => {
     const loading = loader();
     const result = typeof p === 'function' ? p() : p;
     await result;
     loading.stop();
+    return result;
   };
 
   const debug = Boolean(parameters.options.debug);
@@ -82,6 +95,7 @@ export const interfaceHelpers = (toolbox: Toolbox) => {
   return {
     code,
     title,
+    titleSecondary,
     about,
     postInstallInstructions,
     printTask,

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -7,7 +7,7 @@ const camelCase = require('camelcase');
  * @param toolbox
  */
 export const validations = (toolbox: Toolbox) => {
-  const { print, filesystem, system } = toolbox;
+  const { print, filesystem, system, commandName } = toolbox;
   const { cyan, gray } = print.colors;
 
   const validateProjectName = (projectName: string) => {
@@ -39,8 +39,27 @@ export const validations = (toolbox: Toolbox) => {
     }
   };
 
+  /**
+   * Assert CWD is the root of a ReactNative project.
+   */
+  const checkCurrentDirReactNativeProject = async () => {
+    try {
+      // ensure presence of following files to prove that CWD is indeed a ReactNative project root
+      await system.run('cat package.json');
+      await system.run('cat app.json');
+      await system.run('cat ios/Podfile');
+      await system.run('cat android/build.gradle');
+    } catch (err) {
+      print.info(gray(err.message));
+      print.error(`\`airfoil ${commandName}\` was not initiated from a ReactNative project root!`);
+      print.info(gray('Change directory to a ReactNative project root and try again.'));
+      process.exit(1);
+    }
+  };
+
   return {
     validateProjectName,
     checkCocoaPodsInstalled,
+    checkCurrentDirReactNativeProject,
   };
 };


### PR DESCRIPTION
Added the `version` command to make it painless to bump the version number in React Native projects.

_NOTE - had to remove `.version()` from the cli to get this to work. But running `airfoil help` shows the version number anyways. I really wanted to match the pattern that npm uses for advancing the version number (e.g. `npm version minor`)_

This updates the version in `package.json` as well as `ios/` and `android/` directories.

![image](https://user-images.githubusercontent.com/5880655/107864666-99083380-6e2c-11eb-8f92-282918bf7645.png)
