### PR TITLE
Don/cmd tweaks

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -30,17 +30,25 @@ Bump the version number for a React Native project.
 
 This updates the version in `package.json` as well as `ios/` and `android/` directories.
 
+**Args:**
+
+- `--update` (`-u`) - provide an exact version number
+- `--verbose` (`-v`) - print more detailed logs
+
 **Example:**
 
 ```
-# bump version number (patch release e.g. 0.0.1 -> 0.0.2)
+# bump version - patch release (e.g. 0.0.1 -> 0.0.2)
 airfoil version patch
 
-# bump version number (minor release e.g. 0.0.2 -> 0.1.0)
+# bump version - minor release (e.g. 0.0.2 -> 0.1.0)
 airfoil version minor
 
-# bump version number (major release e.g. 0.1.0 -> 1.0.0)
+# bump version - major release (e.g. 0.1.0 -> 1.0.0)
 airfoil version major
+
+# bump version to 2.3.4
+airfoil version -u 2.3.4
 ```
 
 ---
@@ -55,10 +63,14 @@ Add an ENV var.
 
 This updates `.env`, `.env.example`, `app/constants.ts`, and `appcenter-pre-build.sh` all in one go.
 
+NOTE: an ENV value of "true" or "false" is always interpreted as a boolean.
+
 **Args:**
 
 - `--boolean` (`--bool`, `-b`) - process as boolean ENV var
-- `--dry` (`-d`) - perform a dry test run (print out a Git diff of changes without changing any files)
+- `--comment` (`-c`) - add a comment for this ENV var
+- `--dry` (`-d`) - perform a dry test run _(print out a Git diff of changes without changing any files)_
+- `--verbose` (`-v`) - print more detailed logs
 
 **Example:**
 
@@ -69,11 +81,11 @@ airfoil add env
 # add env var SETUP=true
 airfoil add env setup=true
 
-# add env var TEST=true (alternate args)
+# add env var TEST=true (alternative format)
 airfoil add env test true
 
-# add env var DEV=true as a boolean
-airfoil add env dev=true --boolean
+# add env var DEV=mighty as a boolean
+airfoil add env dev=mighty --boolean
 
 # perform dry run
 airfoil add env API_KEY=abc123 --dry

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,6 +1,7 @@
 import { GluegunCommand } from 'gluegun';
 import { print } from 'gluegun/print';
-import { Toolbox } from 'gluegun/build/types/domain/toolbox';
+
+import { GluegunToolboxExtended } from '../extensions/extensions';
 import {
   CHOICE_TEMPLATE_BLIMP,
   CHOICE_TEMPLATE_JET,
@@ -34,7 +35,7 @@ const templateAssociations = {
 const command: GluegunCommand = {
   name: 'new',
   alias: 'n',
-  run: async toolbox => {
+  run: async (toolbox: GluegunToolboxExtended) => {
     const { parameters, print, prompt } = toolbox;
     const { title, about, loadWhile } = interfaceHelpers(toolbox);
     const { validateProjectName, checkCocoaPodsInstalled } = validations(toolbox);
@@ -62,7 +63,11 @@ const command: GluegunCommand = {
   },
 };
 
-const createProject = async (projectName: string, template: RepoLocation, toolbox: Toolbox) => {
+const createProject = async (
+  projectName: string,
+  template: RepoLocation,
+  toolbox: GluegunToolboxExtended,
+) => {
   const { print, filesystem } = toolbox;
   const { log, postInstallInstructions } = interfaceHelpers(toolbox);
 

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,4 +1,4 @@
-import { GluegunToolbox } from 'gluegun';
+import { GluegunToolboxExtended } from '../extensions/extensions';
 import { interfaceHelpers } from '../utils/interface';
 import { validations } from '../utils/validations';
 
@@ -9,12 +9,9 @@ const VERSION_TYPE_PATCH = 'patch';
 const command = {
   name: 'version',
   alias: ['v'],
-  run: async (toolbox: GluegunToolbox) => {
-    const { titleSecondary, about, loadWhile } = interfaceHelpers(toolbox);
+  run: async (toolbox: GluegunToolboxExtended) => {
+    const { loadWhile } = interfaceHelpers(toolbox);
     const { checkCurrentDirReactNativeProject } = validations(toolbox);
-
-    titleSecondary();
-    about();
 
     await loadWhile(checkCurrentDirReactNativeProject());
 
@@ -22,27 +19,26 @@ const command = {
   },
 };
 
-const updateVersion = async (toolbox: GluegunToolbox) => {
-  const { parameters, print } = toolbox;
-  const { gray, cyan, yellow, red, green } = print.colors;
+const updateVersion = async (toolbox: GluegunToolboxExtended) => {
+  const { parameters, print, printV } = toolbox;
+  const { gray, cyan, yellow, red, green, white } = print.colors;
   const { cmd, printTask, loadWhile } = interfaceHelpers(toolbox);
+  const { optUpdate } = toolbox.globalOpts;
 
   const type = parameters.first;
-  if (!type || ![VERSION_TYPE_MAJOR, VERSION_TYPE_MINOR, VERSION_TYPE_PATCH].includes(type)) {
-    printInvalidVersionArgs(toolbox);
-    process.exit(1);
-  }
+  checkParameters(toolbox);
 
-  let typeColor = cyan;
+  let typeColor = white;
+  if (type === VERSION_TYPE_PATCH) typeColor = cyan;
   if (type === VERSION_TYPE_MINOR) typeColor = yellow;
   if (type === VERSION_TYPE_MAJOR) typeColor = red;
 
   const pkgJsonProps: string = await loadWhile(cmd('cat package.json | npx json version name'));
   const [currentVersion, appName] = pkgJsonProps.split(/\n/).filter(w => !!w);
-  print.info(gray(`App: ${appName.replace('\n', '')}`));
-  print.info(gray(`Current version: ${currentVersion.replace('\n', '')}`));
-  print.info(gray(`Version change: ${typeColor(`${type} release`)}`));
-  print.newline();
+  printV.info(gray(`App: ${appName.replace('\n', '')}`));
+  printV.info(gray(`Current version: ${currentVersion.replace('\n', '')}`));
+  if (type) printV.info(gray(`Version change: ${typeColor(`${type} release`)}`));
+  printV.newline();
 
   let task;
   task = printTask('🔬 Checking some things...');
@@ -59,15 +55,15 @@ const updateVersion = async (toolbox: GluegunToolbox) => {
   // see: https://docs.npmjs.com/cli/v6/commands/npm-version
   // see: https://www.npmjs.com/package/react-native-version
   task = printTask('🍳 Cooking version number...');
-  await cmd(`npm --no-git-tag-version version ${type}`);
+  await cmd(`npm --no-git-tag-version version ${optUpdate || type}`);
   const newVersionRaw = await cmd('cat package.json | npx json version');
   const newVersion = newVersionRaw.replace('\n', '');
   await cmd(`npx react-native-version --skip-tag --never-amend`);
   task.stop();
 
-  print.newline();
+  printV.newline();
   print.info(gray(`New version: ${green(newVersion)}`));
-  print.newline();
+  printV.newline();
 
   task = printTask('🎓 Graduating to Git...');
   await cmd(`git tag -a v${newVersion} -m "v${newVersion}"`);
@@ -75,11 +71,23 @@ const updateVersion = async (toolbox: GluegunToolbox) => {
   await cmd(`git commit -m "bump version to ${newVersion}"`);
   task.stop();
 
-  print.newline();
-  print.success(`${print.checkmark} All done!`);
+  printV.newline();
+  printV.success(`${print.checkmark} All done!`);
 };
 
-const printInvalidVersionArgs = (toolbox: GluegunToolbox) => {
+const checkParameters = (toolbox: GluegunToolboxExtended) => {
+  const { parameters } = toolbox;
+  const { optUpdate } = toolbox.globalOpts;
+  if (optUpdate) return;
+
+  const type = parameters.first;
+  if (!type || ![VERSION_TYPE_MAJOR, VERSION_TYPE_MINOR, VERSION_TYPE_PATCH].includes(type)) {
+    printInvalidVersionArgs(toolbox);
+    process.exit(1);
+  }
+};
+
+const printInvalidVersionArgs = (toolbox: GluegunToolboxExtended) => {
   const { print } = toolbox;
   const { gray, cyan } = print.colors;
   print.error(

--- a/src/extensions/example.ts
+++ b/src/extensions/example.ts
@@ -1,14 +1,11 @@
-
-import { GluegunToolbox } from 'gluegun'
-
+import { GluegunToolbox } from 'gluegun';
 
 // add your CLI-specific functionality here, which will then be accessible
 // to your commands
 module.exports = (toolbox: GluegunToolbox) => {
-  toolbox.foo = () => {
-    toolbox.print.info('called foo extension')
-  }
-
+  // toolbox.foo = () => {
+  //   toolbox.print.info('called foo extension')
+  // }
   // enable this if you want to read configuration in from
   // the current folder's package.json (in a "airfoil" property),
   // airfoil.config.json, etc.
@@ -16,4 +13,4 @@ module.exports = (toolbox: GluegunToolbox) => {
   //   ...toolbox.config,
   //   ...toolbox.config.loadConfig("airfoil", process.cwd())
   // }
-}
+};

--- a/src/extensions/extensions.ts
+++ b/src/extensions/extensions.ts
@@ -1,0 +1,71 @@
+import { GluegunToolbox } from 'gluegun';
+
+type Log = (m: string) => string;
+type GlobalOpts = {
+  optDry: boolean;
+  optDebug: boolean;
+  optUpdate: string;
+  optVerbose: boolean;
+  isVerbose: boolean;
+};
+type PrintV = {
+  info: (msg: string) => void;
+  newline: () => void;
+  success: (msg: string) => void;
+  code: (msg: string) => void;
+};
+
+export interface GluegunToolboxExtended extends GluegunToolbox {
+  globalOpts: GlobalOpts;
+  log: Log;
+  printV: PrintV;
+}
+
+const DE_FACTO_VERBOSE_COMMANDS = ['new', 'print'];
+
+module.exports = (toolbox: GluegunToolbox) => {
+  const { print, parameters, commandName } = toolbox;
+  const { gray, bgBlack } = print.colors;
+
+  //
+  // GLOBAL OPTIONS
+  //
+  const optDry = Boolean(parameters.options.dry);
+  const optDebug = Boolean(parameters.options.debug);
+  const optUpdate = parameters.options.update || parameters.options.u;
+  const optVerbose = Boolean(parameters.options.verbose || parameters.options.v);
+  const isVerbose = optVerbose || DE_FACTO_VERBOSE_COMMANDS.includes(commandName);
+  const globalOpts: GlobalOpts = {
+    optDry,
+    optDebug,
+    optUpdate,
+    optVerbose,
+    isVerbose,
+  };
+  toolbox.globalOpts = globalOpts;
+
+  //
+  // DEBUG LOG
+  //
+  const log: Log = (m: string): string => {
+    if (optDebug) print.info(gray(m));
+    return m;
+  };
+  toolbox.log = log;
+
+  //
+  // PRINT EXTENSIONS
+  //
+  const printV: PrintV = {
+    info: isVerbose ? print.info : () => {},
+    newline: isVerbose ? print.newline : () => {},
+    success: isVerbose ? print.success : () => {},
+    code: (msg = '') => {
+      if (!msg) return printV.code(bgBlack(` `));
+      const len = Math.max(60 - msg.length, 0);
+      const ws = ' '.repeat(len);
+      printV.info(`\t${bgBlack(`  ${msg}${ws}  `)}`);
+    },
+  };
+  toolbox.printV = printV;
+};

--- a/src/extensions/extensions.ts
+++ b/src/extensions/extensions.ts
@@ -56,6 +56,7 @@ module.exports = (toolbox: GluegunToolbox) => {
   //
   // PRINT EXTENSIONS
   //
+  // Only print if the `-v` (verbose) option is supplied
   const printV: PrintV = {
     info: isVerbose ? print.info : () => {},
     newline: isVerbose ? print.newline : () => {},

--- a/src/scripts/projectCreation.ts
+++ b/src/scripts/projectCreation.ts
@@ -1,6 +1,6 @@
-import { Toolbox } from 'gluegun/build/types/domain/toolbox';
-import { interfaceHelpers } from '../utils/interface';
+import { GluegunToolboxExtended } from '../extensions/extensions';
 import { AIRSHIP_EMAIL, DEFAULT_PROJECT_VERSION, RepoLocation } from '../constants';
+import { interfaceHelpers } from '../utils/interface';
 const decamelize = require('decamelize');
 
 /**
@@ -12,7 +12,7 @@ const decamelize = require('decamelize');
 export const cloneTemplateRepo = async (
   projectName: string,
   repo: RepoLocation,
-  toolbox: Toolbox,
+  toolbox: GluegunToolboxExtended,
 ) => {
   const { cmd, printTask } = interfaceHelpers(toolbox);
   const task = printTask('☀️  Opening hangar door...');
@@ -28,7 +28,7 @@ export const cloneTemplateRepo = async (
  * 4. Renames the "master" branch to "main"
  * @param toolbox the toolbox object supplied by Gluegun
  */
-export const initializeGit = async (toolbox: Toolbox) => {
+export const initializeGit = async (toolbox: GluegunToolboxExtended) => {
   const { cmd, printTask } = interfaceHelpers(toolbox);
   const task = printTask('🗺️  Creating flight plan and logging point of origin...');
   await cmd(`rm -rf .git`);
@@ -43,7 +43,7 @@ export const initializeGit = async (toolbox: Toolbox) => {
  * Installs all dependencies for a project, including pods.
  * @param toolbox the toolbox object supplied by Gluegun
  */
-export const installDependencies = async (toolbox: Toolbox) => {
+export const installDependencies = async (toolbox: GluegunToolboxExtended) => {
   const { cmd, printTask } = interfaceHelpers(toolbox);
   const task = printTask('🔧 Checking oil levels and fueling up...');
   await cmd(`yarn install --ignore-scripts`);
@@ -57,7 +57,10 @@ export const installDependencies = async (toolbox: Toolbox) => {
  * @param projectName the name of the project
  * @param toolbox the toolbox supplied by Gluegun
  */
-export const initializeProjectInfo = async (projectName: string, toolbox: Toolbox) => {
+export const initializeProjectInfo = async (
+  projectName: string,
+  toolbox: GluegunToolboxExtended,
+) => {
   const { template } = toolbox;
   const { cmd, printTask } = interfaceHelpers(toolbox);
   const task = printTask('🎛️  Setting altimeter and idling engine...');
@@ -81,7 +84,10 @@ export const initializeProjectInfo = async (projectName: string, toolbox: Toolbo
  * ./ios/[APP_NAME].xcodeproj, android app folder names, etc.)
  * @param projectName The name of the project
  */
-export const renameReactNativeProject = async (projectName: string, toolbox: Toolbox) => {
+export const renameReactNativeProject = async (
+  projectName: string,
+  toolbox: GluegunToolboxExtended,
+) => {
   const { cmd, printTask } = interfaceHelpers(toolbox);
   const task = printTask('🎙  Registering call sign...');
   await cmd(`npx react-native-rename ${projectName}`);

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,4 +1,4 @@
-import { GluegunToolbox } from 'gluegun';
+import { GluegunToolboxExtended } from '../extensions/extensions';
 import { interfaceHelpers } from './interface';
 
 const tmp = require('tmp');
@@ -9,16 +9,19 @@ const tmp = require('tmp');
  *
  * **Usage:**
  * ```
- * const [printDiff, cleanup] = toolPrintDiff(toolbox);
- * printDiff(originalContent, newContent);
+ * const { printDiff, cleanupPrintDiff } = toolbox;
+ * printDiff(originalContent, newContent, 'text.txt');
  * // call cleanup() once finished
  * cleanup();
  * ```
  * @param toolbox
  */
 export const toolPrintDiff = (
-  toolbox: GluegunToolbox,
-): [(originalContent: string, newContent: string) => Promise<void>, () => void] => {
+  toolbox: GluegunToolboxExtended,
+): [
+  (originalContent: string, newContent: string, fileName?: string) => Promise<void>,
+  () => void,
+] => {
   const { filesystem, print } = toolbox;
   const { gray, red, green } = print.colors;
   const { path } = filesystem;
@@ -29,10 +32,10 @@ export const toolPrintDiff = (
     tmpDir.removeCallback();
     filesystem.remove(tmpDirPath);
   };
-  const printDiff = async (originalContent: string, newContent: string) => {
+  const printDiff = async (originalContent: string, newContent: string, fileName?: string) => {
     const tempCwd = filesystem.cwd();
     process.chdir(tmpDirPath);
-    const tmpFileName = 'TEMP_CONTENT.txt';
+    const tmpFileName = fileName || 'TEMP_CONTENT.txt';
     const tmpFilepath = path(tmpDirPath, tmpFileName);
     filesystem.dir(tmpDirPath);
     filesystem.remove(path(tmpDirPath, '.git'));

--- a/src/utils/interface.ts
+++ b/src/utils/interface.ts
@@ -96,7 +96,6 @@ export const interfaceHelpers = (toolbox: GluegunToolboxExtended) => {
     postInstallInstructions,
     printTask,
     runTask,
-    printV,
     loader,
     loadWhile,
     cmd,

--- a/src/utils/interface.ts
+++ b/src/utils/interface.ts
@@ -1,4 +1,4 @@
-import { Toolbox } from 'gluegun/build/types/domain/toolbox';
+import { GluegunToolboxExtended } from '../extensions/extensions';
 
 /**
  * Interface Helpers for Humans
@@ -6,15 +6,10 @@ import { Toolbox } from 'gluegun/build/types/domain/toolbox';
  * @see https://github.com/Marak/colors.js
  * @param toolbox
  */
-export const interfaceHelpers = (toolbox: Toolbox) => {
-  const { print, parameters, system, meta, commandName } = toolbox;
+export const interfaceHelpers = (toolbox: GluegunToolboxExtended) => {
+  const { print, printV, parameters, system, meta } = toolbox;
   const { red, gray, cyan, bgBlack } = print.colors;
-
-  const code = (msg: string = '') => {
-    const len = Math.max(60 - msg.length, 0);
-    const ws = ' '.repeat(len);
-    print.info(`\t${bgBlack(`  ${msg}${ws}  `)}`);
-  };
+  const { optDry, isVerbose } = toolbox.globalOpts;
 
   const title = () => {
     print.newline();
@@ -27,47 +22,51 @@ export const interfaceHelpers = (toolbox: Toolbox) => {
     print.newline();
   };
 
-  const titleSecondary = () => {
-    print.newline();
-    const spaceLetters = (w = '') => w.split('').join(' ');
-    const str1 = spaceLetters('AIRFOIL');
-    const str2 = spaceLetters(commandName.toUpperCase());
-    const str = red(` ${str1} ${cyan(str2)} `);
-    const len = Math.max(36 - str1.length - str2.length, 0);
-    const ws = ' '.repeat(Math.floor(len / 2));
-    print.info(gray(`--[${ws}${str} ${ws}]--`));
-    print.newline();
-  };
-
   const about = () => {
     print.info(gray(`Version ${meta.version()}\t\tMade with ♡ by Airship`));
     print.newline();
     print.newline();
   };
 
+  const dryNotice = () => {
+    if (optDry) {
+      print.newline();
+      print.warning('-------------------');
+      print.warning('-- D R Y   R U N --');
+      print.warning('-------------------');
+      print.newline();
+    }
+  };
+
   const postInstallInstructions = (projectName: string) => {
-    print.newline();
-    print.newline();
-    code(bgBlack(` `));
-    code(gray(`You are now ready to hack.`));
-    code(cyan(`cd ${projectName}`));
-    code(cyan(`yarn ios || yarn android `));
-    code(bgBlack(` `));
-    print.newline();
-    print.newline();
+    printV.newline();
+    printV.newline();
+    printV.code(bgBlack(` `));
+    printV.code(gray(`You are now ready to hack.`));
+    printV.code(cyan(`cd ${projectName}`));
+    printV.code(cyan(`yarn ios || yarn android `));
+    printV.code(bgBlack(` `));
+    printV.newline();
+    printV.newline();
   };
 
   type Task = { stop: () => void };
   const printTask = (msg: string): Task => {
-    print.info(msg);
+    printV.info(msg);
     const t = print.spin('');
     return {
       stop: () => t.stop(),
     };
   };
 
+  const runTask = async (msg: string, callback: () => Promise<void>) => {
+    const t = printTask(msg);
+    await callback();
+    t.stop();
+  };
+
   const loader = () => {
-    const t = print.spin(gray('loading...'));
+    const t = print.spin(gray(isVerbose ? 'loading...' : ''));
     return {
       stop: () => t.stop(),
     };
@@ -91,12 +90,13 @@ export const interfaceHelpers = (toolbox: Toolbox) => {
   const cmd = (c: string) => system.run(log(c));
 
   return {
-    code,
     title,
-    titleSecondary,
     about,
+    dryNotice,
     postInstallInstructions,
     printTask,
+    runTask,
+    printV,
     loader,
     loadWhile,
     cmd,


### PR DESCRIPTION
This PR accomplishes the following:

- adds `-u` option for `version` command to set an exact version
- adds `-v` (verbose) option for `version` and `generate env` commands
- adds a working Gluegun extension for simple utilities
- refactors `generate` and `version` commands for minimal output

**screenshawts:**

<img width="345" alt="cmd-env-minimal-output" src="https://user-images.githubusercontent.com/5880655/108314443-e7e4fe80-7187-11eb-8179-a374d1235aec.png">

<img width="340" alt="cmd-version-minimal-output" src="https://user-images.githubusercontent.com/5880655/108314478-f8957480-7187-11eb-8e49-d70b9ad5b831.png">
