### PR TITLE
add cmd: `airfoil generate adr` && clean up `generate` cmd

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -91,6 +91,21 @@ airfoil add env dev=mighty --boolean
 airfoil add env API_KEY=abc123 --dry
 ```
 
+### `generate adr`
+
+Add an Architecture Design Record (ADR).
+
+**Example:**
+
+```
+# follow prompts to add ADR
+airfoil add adr
+
+# specify ADR title as arg1
+airfoil add adr "Choose Cognito for Auth"
+
+```
+
 ---
 
 `help (h)`

--- a/package.json
+++ b/package.json
@@ -42,12 +42,13 @@
     "decamelize": "^5.0.0",
     "jest": "^24.1.0",
     "prettier": "^1.12.1",
+    "snake-case": "^3.0.4",
+    "tmp": "^0.2.1",
     "ts-jest": "^24.1.0",
     "ts-node": "^8.4.1",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.17.0",
     "tslint-config-standard": "^8.0.1",
-    "tmp": "^0.2.1",
     "typescript": "^3.6.3"
   },
   "jest": {

--- a/src/scripts/generateAdr.ts
+++ b/src/scripts/generateAdr.ts
@@ -1,0 +1,73 @@
+import { snakeCase } from 'snake-case';
+import { GluegunToolboxExtended } from '../extensions/extensions';
+import { interfaceHelpers } from '../utils/interface';
+const camelCase = require('camelcase');
+
+const PATH_ADRS = 'adr';
+const PATH_ADR_README = 'adr/__README__.md';
+const REG_ADR_FILENAME = /^(\d{4})_.*\.md$/;
+const INITIAL_ADR_INDEX = 1;
+
+export const generateAdr = async (toolbox: GluegunToolboxExtended, adrTitle: string) => {
+  const { filesystem, print } = toolbox;
+  const { path, cwd } = filesystem;
+  const pathAdrDir = path(cwd(), PATH_ADRS);
+
+  createDirIfNotExists(toolbox, pathAdrDir);
+  const nextIndex = getNextAdrIndex(toolbox, pathAdrDir);
+  const adrFileName = `${nextIndex}_${snakeCase(adrTitle)}.md`;
+  const adrFilePath = path(PATH_ADRS, adrFileName);
+
+  if (!filesystem.exists(PATH_ADR_README)) {
+    const projectName = await getProjectName(toolbox);
+    toolbox.template.generate({
+      template: 'adr-readme-template.ejs',
+      target: PATH_ADR_README,
+      props: { projectName },
+    });
+    print.success(`${print.checkmark} Added ${PATH_ADR_README}`);
+  }
+
+  toolbox.template.generate({
+    template: 'adr-template.ejs',
+    target: adrFilePath,
+    props: { title: adrTitle },
+  });
+  print.success(`${print.checkmark} Added ${PATH_ADRS}/${adrFileName}`);
+};
+
+const createDirIfNotExists = (toolbox: GluegunToolboxExtended, pathAdrDir: string) => {
+  toolbox.filesystem.dir(pathAdrDir);
+};
+
+/**
+ * Iterate through adr/ dir, inspecting each filename to get the next adr index
+ * @param toolbox
+ * @param pathAdrDir
+ */
+const getNextAdrIndex = (toolbox: GluegunToolboxExtended, pathAdrDir: string): string => {
+  const { filesystem } = toolbox;
+  const result = filesystem.inspectTree(pathAdrDir);
+  if (!result || !result.children || !result.children.length) {
+    return INITIAL_ADR_INDEX.toString().padStart(4, '0');
+  }
+
+  let maxIndex = INITIAL_ADR_INDEX;
+  result.children.forEach(child => {
+    if (child.type !== 'file' || !child.name) return;
+    const matches = child.name.match(REG_ADR_FILENAME);
+    if (!matches || !matches[1]) return;
+    const parsedIndex = parseInt(matches[1], 10);
+    if (parsedIndex < maxIndex) return;
+    maxIndex = parsedIndex + 1;
+  });
+
+  const nextIndex = maxIndex;
+  return nextIndex.toString().padStart(4, '0');
+};
+
+const getProjectName = async (toolbox: GluegunToolboxExtended) => {
+  const { cmd } = interfaceHelpers(toolbox);
+  const appNameRaw = await cmd('cat package.json | npx json name');
+  return camelCase(appNameRaw.replace('\n', ''));
+};

--- a/src/scripts/generateEnvVar.ts
+++ b/src/scripts/generateEnvVar.ts
@@ -1,0 +1,107 @@
+import { GluegunToolboxExtended } from '../extensions/extensions';
+import { interfaceHelpers } from '../utils/interface';
+import { toolGetFileContent } from '../utils/content';
+import { toolPrintDiff } from '../utils/diff';
+import { addEnvVar, addConstant, addAppCenterVar } from '../utils/envVar';
+
+export const generateEnvVar = async ({
+  toolbox,
+  envKey = '',
+  envVal = '',
+  envType = 'string',
+  envComment = '',
+}: {
+  toolbox: GluegunToolboxExtended;
+  envKey: string;
+  envVal: string;
+  envType: 'string' | 'boolean';
+  envComment: string;
+}) => {
+  const { dryNotice } = interfaceHelpers(toolbox);
+  dryNotice();
+
+  const [printDiff, cleanup] = toolPrintDiff(toolbox);
+
+  await processEnvFile({
+    filePath: '.env',
+    defaultContent: await defaultContentEnv(toolbox),
+    toNewContent: content => addEnvVar(content, envKey, envVal, envComment),
+    printDiff,
+    toolbox,
+  });
+
+  await processEnvFile({
+    filePath: '.env.example',
+    defaultContent: await defaultContentEnv(toolbox),
+    toNewContent: content => addEnvVar(content, envKey, '', envComment),
+    printDiff,
+    toolbox,
+  });
+
+  await processEnvFile({
+    filePath: 'app/constants.ts',
+    defaultContent: await defaultContentConstants(toolbox),
+    toNewContent: content => addConstant(content, envKey, envComment, envType),
+    printDiff,
+    toolbox,
+  });
+
+  await processEnvFile({
+    filePath: 'appcenter-pre-build.sh',
+    defaultContent: await defaultContentAppCenter(toolbox),
+    toNewContent: content => addAppCenterVar(content, envKey),
+    printDiff,
+    toolbox,
+  });
+
+  cleanup();
+};
+
+const processEnvFile = async ({
+  filePath,
+  defaultContent,
+  toNewContent,
+  printDiff,
+  toolbox,
+  ignoreMissingFile = false,
+}: {
+  filePath: string;
+  defaultContent?: string;
+  toNewContent: (content: string) => string;
+  printDiff: (content: string, newContent: string, fileName?: string) => Promise<void>;
+  toolbox: GluegunToolboxExtended;
+  ignoreMissingFile?: boolean;
+}): Promise<void> => {
+  const { filesystem, print } = toolbox;
+  const { optDry, optVerbose } = toolbox.globalOpts;
+  const getFileContent = toolGetFileContent(toolbox);
+  try {
+    const content = getFileContent(filePath, defaultContent, ignoreMissingFile);
+    if (typeof content !== 'string') return;
+
+    const newContent = toNewContent(content);
+
+    if (optDry || optVerbose) await printDiff(content, newContent, filePath);
+    if (optDry) return;
+
+    filesystem.write(filePath, newContent);
+    print.success(`${print.checkmark} updated ${filePath}`);
+  } catch (err) {
+    print.error(err);
+  }
+};
+
+const defaultContentEnv = async (toolbox: GluegunToolboxExtended) =>
+  toolbox.template.generate({
+    template: '.env.ejs',
+  });
+
+const defaultContentConstants = async (toolbox: GluegunToolboxExtended) =>
+  toolbox.template.generate({
+    template: 'constants.ts.ejs',
+  });
+
+const defaultContentAppCenter = async (toolbox: GluegunToolboxExtended) =>
+  toolbox.template.generate({
+    template: 'appcenter-pre-build.sh.ejs',
+  });

--- a/src/templates/adr-readme-template.ejs
+++ b/src/templates/adr-readme-template.ejs
@@ -1,0 +1,5 @@
+# <%= props.projectName %> Architecture Decision Records (ADRs)
+
+In this directory you can find a record of architecture decisions. The
+purpose of this is to document decisions that were made, and why they were
+made, and help to provide context to future developers who work on this project.

--- a/src/templates/adr-template.ejs
+++ b/src/templates/adr-template.ejs
@@ -1,0 +1,23 @@
+# <%= props.title || Title %>
+
+## Status
+
+What is the status, such as `proposed`, `accepted`, `rejected`, `deprecated`, `superseded`, etc.?
+
+---
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+---
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+---
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?

--- a/src/templates/upload-bugsnag-sourcemaps.sh.ejs
+++ b/src/templates/upload-bugsnag-sourcemaps.sh.ejs
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Bugsnag sourcemaps bundle && upload script
+
+#
+# UTILS
+#
+
+# taken from: https://gist.github.com/judy2k/7656bfe3b322d669ef75364a46327836#gistcomment-2882842
+read_env_var() {
+  VAR=$(grep "^$1=" .env | xargs)
+  IFS="=" read -ra VAR <<< "$VAR"
+  IFS=" "
+  echo ${VAR[1]}
+}
+
+# taken from https://gist.github.com/DarrenN/8c6a5b969481725a4413
+read_package_json_version() {
+  # Version key/value should be on its own line
+  VAR=$(cat package.json \
+    | grep version \
+    | head -1 \
+    | awk -F: '{ print $2 }' \
+    | sed 's/[",]//g')
+  echo $VAR
+}
+
+#
+# CONFIG
+#
+
+ENVS=(
+  testflight
+  production
+)
+APP_VERSION=$(read_package_json_version)
+BUGSNAG_API_KEY=$(read_env_var BUGSNAG_API_KEY)
+# clean up sourcemap bundles
+CLEANUP=true
+
+# IF bugsnag ENV var unset, die
+if [ -z "$BUGSNAG_API_KEY" ]; then
+  echo "BUGSNAG_API_KEY is not set!!";
+  exit 1
+fi
+
+#
+# SCRIPT
+#
+
+echo
+echo "###########################"
+echo "### BUGSNAG SOURCE MAPS ###"
+echo "###########################"
+echo
+echo "App version: '${APP_VERSION}'"
+
+for ENV in "${ENVS[@]}"; do
+
+  DEV=false
+  if [ $ENV = "debug" ] || [ $ENV = "development" ] ; then
+    DEV=true
+  fi
+  VARIANT="Release"
+  if [ $DEV = true ] ; then
+    VARIANT="Debug"
+  fi
+
+  
+  echo
+  echo "Variant: '${VARIANT}'"
+  echo "Generating ios source map for '${ENV}'..."
+
+  npx react-native bundle \
+    --platform ios \
+    --dev ${DEV} \
+    --entry-file index.js \
+    --bundle-output ios-${ENV}.bundle \
+    --sourcemap-output ios-${ENV}.bundle.map
+
+  echo "OK"
+  echo "Generating android source map for '${ENV}'..."
+
+  npx react-native bundle \
+    --platform android \
+    --dev ${DEV} \
+    --entry-file index.js \
+    --bundle-output android-${ENV}.bundle \
+    --sourcemap-output android-${ENV}.bundle.map
+
+  echo "OK"
+  echo "Uploading ios source map to bugsnag..."
+
+  curl --http1.1 https://upload.bugsnag.com/react-native-source-map \
+    -F apiKey=$BUGSNAG_API_KEY \
+    -F appVersion=$APP_VERSION \
+    -F dev=$DEV \
+    -F platform=ios \
+    -F sourceMap=@ios-${ENV}.bundle.map \
+    -F bundle=@ios-${ENV}.bundle \
+    -F projectRoot=$(pwd)
+
+  echo "Uploading android source map to bugsnag..."
+
+  curl --http1.1 https://upload.bugsnag.com/react-native-source-map \
+    -F apiKey=$BUGSNAG_API_KEY \
+    -F appVersion=$APP_VERSION \
+    -F dev=$DEV \
+    -F platform=android \
+    -F sourceMap=@android-${ENV}.bundle.map \
+    -F bundle=@android-${ENV}.bundle \
+    -F projectRoot=$(pwd)
+
+  if [ $CLEANUP ]; then
+    echo "Cleaning up..."
+    rm ios-${ENV}.bundle
+    rm ios-${ENV}.bundle.map
+    rm android-${ENV}.bundle
+    rm android-${ENV}.bundle.map
+  fi
+
+done # for ENV in ENVS
+
+echo "✓ done"

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -13,6 +13,7 @@ import { GluegunToolbox } from 'gluegun';
 export const toolGetFileContent = (toolbox: GluegunToolbox) => (
   filePath: string,
   defaultContent: string,
+  ignoreMissingFile?: boolean,
 ) => {
   const { filesystem, print } = toolbox;
 
@@ -23,7 +24,9 @@ export const toolGetFileContent = (toolbox: GluegunToolbox) => (
       return defaultContent;
     }
 
-    print.warning(`WARNING: file \`${filesystem.cwd()}/${filePath}\` does not exist! Skipping`);
+    if (!ignoreMissingFile) {
+      print.warning(`WARNING: file \`${filesystem.cwd()}/${filePath}\` does not exist! Skipping`);
+    }
     return;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,6 +1141,14 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
+dot-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
+  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -3429,6 +3437,14 @@ slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+
+snake-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
+  integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
This PR does the following:
- adds the `airfoil <generate|add> adr` command
- de-clutters `generate` code
- ensures developer is in a React Native proj when running `airfoil generate ...`

<img width="461" alt="cmd-add-adr" src="https://user-images.githubusercontent.com/5880655/108439579-8f614000-721f-11eb-8154-68d824658183.png">
