### PR TITLE
cmd - airfoil add keystore

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/node": "^12.7.11",
     "camelcase": "^6.2.0",
     "constant-case": "^3.0.4",
+    "dashify": "^2.0.0",
     "date-fns": "^2.18.0",
     "decamelize": "^5.0.0",
     "jest": "^24.1.0",

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -49,6 +49,7 @@ const command: GluegunCommand = {
     if (!fileCategory) {
       const informBadInput = userCategoryInput && !fileCategory;
       const { category } = await prompt.ask([questionFileCategory(informBadInput)]);
+      // @ts-ignore
       fileCategory = FileCategory[category.toLowerCase()];
     }
 

--- a/src/templates/android/keystore.properties.ejs
+++ b/src/templates/android/keystore.properties.ejs
@@ -1,0 +1,4 @@
+keyAlias <%= props.keystoreAlias %>
+keyPassword <%= props.keyPassword %>
+storeFile ./<%= props.keystoreFilepath %>
+storePassword <%= props.keystorePassword %>

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -1,4 +1,6 @@
 import { GluegunToolbox } from 'gluegun';
+import { GluegunTemplateGenerateOptions } from 'gluegun/build/types/toolbox/template-types';
+import { GluegunToolboxExtended } from '../extensions/extensions';
 
 /**
  * Tool: `getFileContent`
@@ -32,4 +34,29 @@ export const toolGetFileContent = (toolbox: GluegunToolbox) => (
 
   const content = filesystem.read(filePath);
   return content;
+};
+
+export const addTemplateAndPromptIfExisting = async (
+  toolbox: GluegunToolboxExtended,
+  generateOptions: GluegunTemplateGenerateOptions,
+) => {
+  const { template, filesystem, prompt, print } = toolbox;
+  const { yellow } = print.colors;
+  const { target } = generateOptions;
+
+  let textAction = 'added';
+  if (filesystem.exists(target)) {
+    const { confirmed } = await prompt.ask([
+      {
+        type: 'confirm',
+        name: 'confirmed',
+        message: `${yellow(target)} already exists - overwrite?`,
+      },
+    ]);
+    if (!confirmed) return;
+    textAction = 'updated';
+  }
+
+  await template.generate(generateOptions);
+  print.success(`${print.checkmark} ${textAction} ${target}`);
 };

--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -1,0 +1,27 @@
+const LOWERCASE_CHARS = 'abcdefghijklmnopqrswuvwxyz';
+const UPPERCASE_CHARS = 'ABCDEFGHIJKLMNOPQRSWUVWXY';
+const NUMERIC_CHARS = '0123456789';
+const DEFAULT_VALID_CHARS = UPPERCASE_CHARS + LOWERCASE_CHARS + NUMERIC_CHARS;
+
+export const generatePassword = (length = 50, tries = 0) => {
+  let passphrase = '';
+  for (let i = 0; i < length; i++) {
+    passphrase += DEFAULT_VALID_CHARS[Math.floor(Math.random() * DEFAULT_VALID_CHARS.length)];
+  }
+
+  // make sure password is valid
+  let hasAlphaLower = false;
+  let hasAlphaUpper = false;
+  let hasNumber = false;
+  for (let i = 0; i < passphrase.length; i++) {
+    if (LOWERCASE_CHARS.includes(passphrase[i])) hasAlphaLower = true;
+    if (UPPERCASE_CHARS.includes(passphrase[i])) hasAlphaUpper = true;
+    if (NUMERIC_CHARS.includes(passphrase[i])) hasNumber = true;
+  }
+  if (!hasAlphaLower || !hasAlphaUpper || !hasNumber) {
+    if (tries > 10) throw new Error(`Could not generate password after ${tries} tries.`);
+    return generatePassword(length, tries + 1);
+  }
+
+  return passphrase;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1025,6 +1025,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+dashify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dashify/-/dashify-2.0.0.tgz#fff270ca2868ca427fee571de35691d6e437a648"
+  integrity sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==
+
 data-urls@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"


### PR DESCRIPTION
This PR adds the command: `airfoil add keystore`.

This is for generating a new Android keystore for a new React Native app.

Example printout:

![image](https://user-images.githubusercontent.com/5880655/116174983-7a9c9f00-a6dd-11eb-9774-a27683ed1500.png)
