### PR TITLE
fix `convert svg` bug for svgs with inline style tags

### DIFF
--- a/src/templates/svgr/.svgo.yml.ejs
+++ b/src/templates/svgr/.svgo.yml.ejs
@@ -1,5 +1,6 @@
 multipass: true
 
+<!-- See here for a list of what these plugins do: https://github.com/svg/svgo#built-in-plugins -->
 plugins:
   - addAttributesToSVGElement: false
   - addClassesToSVGElement: false
@@ -25,15 +26,15 @@ plugins:
   - removeDimensions: true
   - removeDoctype: true
   - removeEditorsNSData: true
-  - removeElementsByAttr: true
+  - removeElementsByAttr: false
   - removeEmptyAttrs: true
   - removeEmptyContainers: true
   - removeEmptyText: true
   - removeHiddenElems: true
   - removeMetadata: true
   - removeNonInheritableGroupAttrs: true
-  - removeRasterImages
-  - removeStyleElement: true
+  - removeRasterImages: true
+  - removeStyleElement: false
   - removeTitle: true
   - removeUnknownsAndDefaults: true
   - removeUnusedNS: true


### PR DESCRIPTION
## What this PR does:

- fix `convert svg` bug for svgs with inline style tags (issue #35 )
- only print out files that were changed
- remove generated index.tsx file
- run prettier on generated .tsx files

![image](https://user-images.githubusercontent.com/5880655/117357558-17e89780-ae83-11eb-9ce3-5a4237443d52.png)

After subsequent run:

![image](https://user-images.githubusercontent.com/5880655/117357639-3189df00-ae83-11eb-845c-c4d5fcd69807.png)
