### PR TITLE
Add help script to catch "--help" commands

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,5 +1,6 @@
 import * as _ from 'lodash';
 import { constantCase } from 'constant-case';
+import { GluegunCommand } from 'gluegun';
 
 import { GluegunToolboxExtended } from '../extensions/extensions';
 import { generateAdr } from '../scripts/generateAdr';
@@ -11,6 +12,8 @@ import { generateAppCenterContent } from '../scripts/generateAppCenterContent';
 import { getProjectName } from '../utils/meta';
 import { generatePassword } from '../utils/password';
 import { addTemplateAndPromptIfExisting } from '../utils/content';
+import { checkCommandHelp } from '../scripts/help';
+import { ADD_DESCRIPTION } from '../constants';
 
 const { padEnd, kebabCase } = _;
 
@@ -22,10 +25,12 @@ const TYPE_KEYSTORE = 'keystore';
 const VALID_TYPES = [TYPE_ENV, TYPE_ADR, TYPE_APPCENTER, TYPE_APPCENTER_ALT, TYPE_KEYSTORE];
 type ENV_TYPE = 'string' | 'boolean';
 
-const command = {
+const command: GluegunCommand = {
   name: 'add',
   alias: ['gen', 'g', 'add', 'a'],
+  description: ADD_DESCRIPTION,
   run: async (toolbox: GluegunToolboxExtended) => {
+    checkCommandHelp(toolbox);
     const { parameters } = toolbox;
     const { loadWhile } = interfaceHelpers(toolbox);
     const { checkCurrentDirReactNativeProject } = validations(toolbox);

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -13,7 +13,7 @@ import { getProjectName } from '../utils/meta';
 import { generatePassword } from '../utils/password';
 import { addTemplateAndPromptIfExisting } from '../utils/content';
 import { checkCommandHelp } from '../scripts/help';
-import { ADD_DESCRIPTION } from '../constants';
+import { HELP_DESCRIPTION_CMD_ADD } from '../constants';
 
 const { padEnd, kebabCase } = _;
 
@@ -28,7 +28,7 @@ type ENV_TYPE = 'string' | 'boolean';
 const command: GluegunCommand = {
   name: 'add',
   alias: ['gen', 'g', 'add', 'a'],
-  description: ADD_DESCRIPTION,
+  description: HELP_DESCRIPTION_CMD_ADD,
   run: async (toolbox: GluegunToolboxExtended) => {
     checkCommandHelp(toolbox);
     const { parameters } = toolbox;

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -1,14 +1,19 @@
+import { GluegunCommand } from 'gluegun';
 import { GluegunToolboxExtended } from '../extensions/extensions';
 import { convertSvg } from '../scripts/convertSvg';
 import { interfaceHelpers } from '../utils/interface';
 import { validations } from '../utils/validations';
+import { checkCommandHelp } from '../scripts/help';
+import { CONVERT_DESCRIPTION } from '../constants';
 
 const TYPE_SVG = 'svg';
 const VALID_TYPES = [TYPE_SVG];
 
-const command = {
+const command: GluegunCommand = {
   name: 'convert',
+  description: CONVERT_DESCRIPTION,
   run: async (toolbox: GluegunToolboxExtended) => {
+    checkCommandHelp(toolbox);
     const { parameters } = toolbox;
     const { loadWhile } = interfaceHelpers(toolbox);
     const { checkCurrentDirReactNativeProject } = validations(toolbox);

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -4,14 +4,14 @@ import { convertSvg } from '../scripts/convertSvg';
 import { interfaceHelpers } from '../utils/interface';
 import { validations } from '../utils/validations';
 import { checkCommandHelp } from '../scripts/help';
-import { CONVERT_DESCRIPTION } from '../constants';
+import { HELP_DESCRIPTION_CMD_CONVERT } from '../constants';
 
 const TYPE_SVG = 'svg';
 const VALID_TYPES = [TYPE_SVG];
 
 const command: GluegunCommand = {
   name: 'convert',
-  description: CONVERT_DESCRIPTION,
+  description: HELP_DESCRIPTION_CMD_CONVERT,
   run: async (toolbox: GluegunToolboxExtended) => {
     checkCommandHelp(toolbox);
     const { parameters } = toolbox;

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -5,7 +5,7 @@ import {
   questionFileCategory,
   questionFileName,
   questionTakenFileName,
-  CREATE_DESCRIPTION,
+  HELP_DESCRIPTION_CMD_CREATE,
 } from '../constants';
 import { interfaceHelpers } from '../utils/interface';
 import { validations } from '../utils/validations';
@@ -32,7 +32,7 @@ function getDirectoryName(
 const command: GluegunCommand = {
   name: 'create',
   alias: ['c', 'generate', 'g'],
-  description: CREATE_DESCRIPTION,
+  description: HELP_DESCRIPTION_CMD_CREATE,
   run: async (toolbox: GluegunToolboxExtended) => {
     checkCommandHelp(toolbox);
     const { filesystem, parameters, prompt, print } = toolbox;

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -5,9 +5,11 @@ import {
   questionFileCategory,
   questionFileName,
   questionTakenFileName,
+  CREATE_DESCRIPTION,
 } from '../constants';
 import { interfaceHelpers } from '../utils/interface';
 import { validations } from '../utils/validations';
+import { checkCommandHelp } from '../scripts/help';
 
 function getDirectoryName(
   fileCategory: FileCategory,
@@ -30,7 +32,9 @@ function getDirectoryName(
 const command: GluegunCommand = {
   name: 'create',
   alias: ['c', 'generate', 'g'],
+  description: CREATE_DESCRIPTION,
   run: async (toolbox: GluegunToolboxExtended) => {
+    checkCommandHelp(toolbox);
     const { filesystem, parameters, prompt, print } = toolbox;
     const { loadWhile } = interfaceHelpers(toolbox);
     const { checkCurrentDirReactNativeProject } = validations(toolbox);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,7 +1,14 @@
 import { GluegunCommand } from 'gluegun';
 import { print } from 'gluegun/print';
-import { Choice, questionProjectName, questionProjectType, Template } from '../constants';
+import {
+  Choice,
+  questionProjectName,
+  questionProjectType,
+  Template,
+  INIT_DESCRIPTION,
+} from '../constants';
 import { GluegunToolboxExtended } from '../extensions/extensions';
+import { checkCommandHelp } from '../scripts/help';
 import {
   cloneTemplateRepo,
   initializeGit,
@@ -24,7 +31,9 @@ const templateAssociations: { [key: string]: Template } = {
 const command: GluegunCommand = {
   name: 'init',
   alias: ['i', 'new'],
+  description: INIT_DESCRIPTION,
   run: async (toolbox: GluegunToolboxExtended) => {
+    checkCommandHelp(toolbox);
     const { parameters, print, prompt } = toolbox;
     const { title, about, loadWhile } = interfaceHelpers(toolbox);
     const { validateProjectName, checkCocoaPodsInstalled } = validations(toolbox);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,7 +5,7 @@ import {
   questionProjectName,
   questionProjectType,
   Template,
-  INIT_DESCRIPTION,
+  HELP_DESCRIPTION_CMD_INIT,
 } from '../constants';
 import { GluegunToolboxExtended } from '../extensions/extensions';
 import { checkCommandHelp } from '../scripts/help';
@@ -31,7 +31,7 @@ const templateAssociations: { [key: string]: Template } = {
 const command: GluegunCommand = {
   name: 'init',
   alias: ['i', 'new'],
-  description: INIT_DESCRIPTION,
+  description: HELP_DESCRIPTION_CMD_INIT,
   run: async (toolbox: GluegunToolboxExtended) => {
     checkCommandHelp(toolbox);
     const { parameters, print, prompt } = toolbox;

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,15 +1,20 @@
+import { GluegunCommand } from 'gluegun';
 import { GluegunToolboxExtended } from '../extensions/extensions';
 import { interfaceHelpers } from '../utils/interface';
 import { validations } from '../utils/validations';
+import { VERSION_DESCRIPTION } from '../constants';
+import { checkCommandHelp } from '../scripts/help';
 
 const VERSION_TYPE_MAJOR = 'major';
 const VERSION_TYPE_MINOR = 'minor';
 const VERSION_TYPE_PATCH = 'patch';
 
-const command = {
+const command: GluegunCommand = {
   name: 'version',
   alias: ['v'],
+  description: VERSION_DESCRIPTION,
   run: async (toolbox: GluegunToolboxExtended) => {
+    checkCommandHelp(toolbox);
     const { loadWhile } = interfaceHelpers(toolbox);
     const { checkCurrentDirReactNativeProject } = validations(toolbox);
 

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -2,7 +2,7 @@ import { GluegunCommand } from 'gluegun';
 import { GluegunToolboxExtended } from '../extensions/extensions';
 import { interfaceHelpers } from '../utils/interface';
 import { validations } from '../utils/validations';
-import { VERSION_DESCRIPTION } from '../constants';
+import { HELP_DESCRIPTION_CMD_VERSION } from '../constants';
 import { checkCommandHelp } from '../scripts/help';
 
 const VERSION_TYPE_MAJOR = 'major';
@@ -12,7 +12,7 @@ const VERSION_TYPE_PATCH = 'patch';
 const command: GluegunCommand = {
   name: 'version',
   alias: ['v'],
-  description: VERSION_DESCRIPTION,
+  description: HELP_DESCRIPTION_CMD_VERSION,
   run: async (toolbox: GluegunToolboxExtended) => {
     checkCommandHelp(toolbox);
     const { loadWhile } = interfaceHelpers(toolbox);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -75,3 +75,21 @@ export const questionTakenFileName = {
   message:
     "Looks like there's already a file with that name. What would you like to name your file?",
 };
+
+// ------------------------
+// ----- DESCRIPTIONS -----
+// ------------------------
+export const ADD_DESCRIPTION =
+  '\nairfoil add [env | appcenter | adr | keystore]\n\nUsage:\n\nairfoil add env # if args omitted -> prompts to get ENV key, value\nairfoil add env MY_VAR=mydatahere\nairfoil add appcenter # follow prompts\nairfoil add adr # follow prompts\nairfoil add adr "Choose Cognito for Auth" # specify ADR title as arg1\nairfoil add keystore\n\nFor more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/add';
+
+export const CONVERT_DESCRIPTION =
+  '\nairfoil convert [svg]\n\nUsage:\n\nairfoil convert svg\nairfoil convert svg --cleanup # to remove app/assets/svg after successful conversion\n\nConverts .svg files to .tsx files for use in React Native. For more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/convert';
+
+export const CREATE_DESCRIPTION =
+  '\nairfoil [create | c]\n\nUsage:\n\nairfoil create # guides you through a quick wizard\nairfoil create component [ComponentName] [-f folderName]\nairfoil create hook [useHookName] [-f folderName]\n\nCreates a file and places it in the correct directory. Currently supported options:\n- component\n- hook. For more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/create';
+
+export const INIT_DESCRIPTION =
+  '\nairfoil [init | i | new] [nameOfProject]\n\nUsage:\n\nairfoil init myAwesomeApp\nairfoil init # prompts you for the <appName>\n\nInitializes a new React Native project. For more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/init';
+
+export const VERSION_DESCRIPTION =
+  '\nairfoil version [major | minor | patch]\n\nUsage:\n\nairfoil version patch # patch release (0.0.1 -> 0.0.2)\nairfoil version minor # minor release (0.0.2 -> 0.1.0)\nairfoil version major # major release (0.1.0 -> 1.0.0)\nairfoil version -u 4.5.6 # update exact version\n\nUpdates the version in package.json as well as ios/ and android/ directories. For more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/version';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -79,17 +79,17 @@ export const questionTakenFileName = {
 // ------------------------
 // ----- DESCRIPTIONS -----
 // ------------------------
-export const ADD_DESCRIPTION =
+export const HELP_DESCRIPTION_CMD_ADD =
   '\nairfoil add [env | appcenter | adr | keystore]\n\nUsage:\n\nairfoil add env # if args omitted -> prompts to get ENV key, value\nairfoil add env MY_VAR=mydatahere\nairfoil add appcenter # follow prompts\nairfoil add adr # follow prompts\nairfoil add adr "Choose Cognito for Auth" # specify ADR title as arg1\nairfoil add keystore\n\nFor more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/add';
 
-export const CONVERT_DESCRIPTION =
+export const HELP_DESCRIPTION_CMD_CONVERT =
   '\nairfoil convert [svg]\n\nUsage:\n\nairfoil convert svg\nairfoil convert svg --cleanup # to remove app/assets/svg after successful conversion\n\nConverts .svg files to .tsx files for use in React Native. For more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/convert';
 
-export const CREATE_DESCRIPTION =
+export const HELP_DESCRIPTION_CMD_CREATE =
   '\nairfoil [create | c]\n\nUsage:\n\nairfoil create # guides you through a quick wizard\nairfoil create component [ComponentName] [-f folderName]\nairfoil create hook [useHookName] [-f folderName]\n\nCreates a file and places it in the correct directory. Currently supported options:\n- component\n- hook. For more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/create';
 
-export const INIT_DESCRIPTION =
+export const HELP_DESCRIPTION_CMD_INIT =
   '\nairfoil [init | i | new] [nameOfProject]\n\nUsage:\n\nairfoil init myAwesomeApp\nairfoil init # prompts you for the <appName>\n\nInitializes a new React Native project. For more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/init';
 
-export const VERSION_DESCRIPTION =
+export const HELP_DESCRIPTION_CMD_VERSION =
   '\nairfoil version [major | minor | patch]\n\nUsage:\n\nairfoil version patch # patch release (0.0.1 -> 0.0.2)\nairfoil version minor # minor release (0.0.2 -> 0.1.0)\nairfoil version major # major release (0.1.0 -> 1.0.0)\nairfoil version -u 4.5.6 # update exact version\n\nUpdates the version in package.json as well as ios/ and android/ directories. For more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/version';

--- a/src/scripts/help.ts
+++ b/src/scripts/help.ts
@@ -1,0 +1,14 @@
+import { GluegunToolboxExtended } from '../extensions/extensions';
+
+export const OPTION_HELP = 'help';
+
+export const checkCommandHelp = (toolbox: GluegunToolboxExtended) => {
+  const { print, parameters } = toolbox;
+  const options = parameters.options;
+  const helpOption = options[OPTION_HELP];
+
+  if (helpOption) {
+    print.info(toolbox.command.description);
+    process.exit(1);
+  }
+};


### PR DESCRIPTION
### What this PR does:
---
Addresses issue #36 
- Add help script to all commands to catch "--help"
- Add descriptions for each command that links to the official documentation
- Add `GluegunCommand` typing to a few commands

Example of `airfoil add --help`:
![Screen Shot 2021-05-17 at 10 09 19 AM](https://user-images.githubusercontent.com/36755092/118512607-93a2d980-b6f8-11eb-889d-95105fc4fb13.png)

Example of `airfoil --help`:
![Screen Shot 2021-05-17 at 10 08 08 AM](https://user-images.githubusercontent.com/36755092/118512579-8e458f00-b6f8-11eb-8d62-fc9a78e4bf00.png)

