### PR TITLE
make version command a lot quicker, update prompt copy

### DIFF
--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -27,7 +27,7 @@ const command: GluegunCommand = {
 const updateVersion = async (toolbox: GluegunToolboxExtended) => {
   const { parameters, print, printV } = toolbox;
   const { gray, cyan, yellow, red, green, white } = print.colors;
-  const { cmd, printTask, loadWhile } = interfaceHelpers(toolbox);
+  const { cmd, printTask, loadWhile, sleep } = interfaceHelpers(toolbox);
   const { optUpdate } = toolbox.globalOpts;
 
   const type = parameters.first;
@@ -59,23 +59,22 @@ const updateVersion = async (toolbox: GluegunToolboxExtended) => {
   // update package.json, ios, android version
   // see: https://docs.npmjs.com/cli/v6/commands/npm-version
   // see: https://www.npmjs.com/package/react-native-version
-  task = printTask('🍳 Cooking version number...');
+  task = printTask('🛩  Prepping next prototype for release...');
   await cmd(`npm --no-git-tag-version version ${optUpdate || type}`);
   const newVersionRaw = await cmd('cat package.json | npx json version');
   const newVersion = newVersionRaw.replace('\n', '');
   await cmd(`npx react-native-version --skip-tag --never-amend`);
   task.stop();
 
-  printV.newline();
-  print.info(gray(`New version: ${green(newVersion)}`));
-  printV.newline();
-
-  task = printTask('🎓 Graduating to Git...');
+  task = printTask('📒 Updating Flight Ledger...');
   await cmd(`git tag -a v${newVersion} -m "v${newVersion}"`);
   await cmd(`git add --all`);
-  await cmd(`git commit -m "bump version to ${newVersion}"`);
+  await cmd(`git commit -m "bump version to ${newVersion}" --no-verify`);
+  await sleep(500);
   task.stop();
 
+  printV.newline();
+  print.info(gray(`New version: ${green(newVersion)}`));
   printV.newline();
   printV.success(`${print.checkmark} All done!`);
 };

--- a/src/utils/interface.ts
+++ b/src/utils/interface.ts
@@ -96,6 +96,13 @@ export const interfaceHelpers = (toolbox: GluegunToolboxExtended) => {
 
   const cmd = (c: string) => system.run(log(c));
 
+  const sleep = (time: number = 1000): Promise<void> =>
+    new Promise(resolve => {
+      setTimeout(() => {
+        resolve();
+      }, time);
+    });
+
   return {
     title,
     about,
@@ -108,6 +115,7 @@ export const interfaceHelpers = (toolbox: GluegunToolboxExtended) => {
     loadWhile,
     cmd,
     log,
+    sleep,
     debug,
   };
 };


### PR DESCRIPTION
This PR does the following:

- adds `--no-verify` to the `git commit` cmd for `airfoil version` --> Since the changes never include files in the codebase, pre-commit hooks (like linting) should never need to be run. This drastically speeds up this command if a project has pre-commit hooks enabled
- updates the prompt text for `airfoil version` command to achieve branding consistency

Demo:

https://user-images.githubusercontent.com/5880655/119030239-9e1ed680-b977-11eb-8bb7-54591f6d3f56.mov

Verbose mode:

![image](https://user-images.githubusercontent.com/5880655/119030452-e63df900-b977-11eb-8f2d-aeafa3a0aa44.png)
