### PR TITLE
fix AppIcon images not linked in new ios app

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -97,7 +97,6 @@ export const HELP_DESCRIPTION_CMD_VERSION =
 // --------------------------
 // ----- APP ICON SIZES -----
 // --------------------------
-type OS = 'ios' | 'android';
 type AppIconConfig = {
   filename: string;
   width: number;
@@ -107,7 +106,12 @@ type AppIconConfig = {
 };
 type AppIconAndroidFlavors = Omit<AppIconConfig, 'width' | 'height'>[];
 type AppIconSettings = {
-  [key in OS]: {
+  ios: {
+    iconFolderPath: string;
+    iconsetContentsPath: string;
+    icons: AppIconConfig[];
+  };
+  android: {
     iconFolderPath: string;
     icons: AppIconConfig[];
     iconFlavors?: AppIconAndroidFlavors;
@@ -129,7 +133,8 @@ export const APP_ICON_SETTINGS: AppIconSettings = {
     ],
   },
   ios: {
-    iconFolderPath: 'ios/%s/Images.xcassets/AppIcon.appiconset',
+    iconFolderPath: 'ios/__PROJECT_NAME__/Images.xcassets/AppIcon.appiconset',
+    iconsetContentsPath: 'ios/__PROJECT_NAME__/Images.xcassets/AppIcon.appiconset/Contents.json',
     icons: [
       { filename: 'Icon-App-20x20@2x.png', width: 40, height: 40 },
       { filename: 'Icon-App-20x20@3x.png', width: 60, height: 60 },

--- a/src/templates/ios/Images.xcassets/AppIcon.appiconset/contents.json.ejs
+++ b/src/templates/ios/Images.xcassets/AppIcon.appiconset/contents.json.ejs
@@ -1,0 +1,62 @@
+{
+  "images": [
+    {
+      "filename": "Icon-App-20x20@2x.png",
+      "idiom": "iphone",
+      "scale": "2x",
+      "size": "20x20"
+    },
+    {
+      "filename": "Icon-App-20x20@3x.png",
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "20x20"
+    },
+    {
+      "filename": "Icon-App-29x29@2x.png",
+      "idiom": "iphone",
+      "scale": "2x",
+      "size": "29x29"
+    },
+    {
+      "filename": "Icon-App-29x29@3x.png",
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "29x29"
+    },
+    {
+      "filename": "Icon-App-40x40@2x.png",
+      "idiom": "iphone",
+      "scale": "2x",
+      "size": "40x40"
+    },
+    {
+      "filename": "Icon-App-40x40@3x.png",
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "40x40"
+    },
+    {
+      "filename": "Icon-App-60x60@2x.png",
+      "idiom": "iphone",
+      "scale": "2x",
+      "size": "60x60"
+    },
+    {
+      "filename": "Icon-App-60x60@3x.png",
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "60x60"
+    },
+    {
+      "filename": "ItunesArtwork@2x.png",
+      "idiom": "ios-marketing",
+      "scale": "1x",
+      "size": "1024x1024"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}


### PR DESCRIPTION
**Because:**

- Issue was raised: https://github.com/teamairship/airfoil/issues/43

**This PR:**

- Fixes the above issue

**Screenshots:**

![image](https://user-images.githubusercontent.com/5880655/128781595-eea984fc-9509-49c2-ab31-b23e2b65934a.png)

![airfoil-ios-contents-json](https://user-images.githubusercontent.com/5880655/128781662-02a3ee6e-528f-466f-b7b0-02571c82c7a9.png)

