### PR TITLE
Don/add default cmd

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,9 +23,11 @@ npm install @airship/airfoil -g
 airfoil <CMD>
 ```
 
-[See Airfoil Documentation](https://airfoil-docs.herokuapp.com/) ([Docs sourcecode](https://github.com/teamairship/airfoil-docs)).
+[See Airfoil Documentation](https://airfoil.teamairship.com/) ([Docs sourcecode](https://github.com/teamairship/airfoil-docs)).
 
 ---
+
+This CLI tool was built with [Gluegun](https://github.com/infinitered/gluegun)
 
 ## Customizing your CLI
 

--- a/src/commands/_defaultCommand.ts
+++ b/src/commands/_defaultCommand.ts
@@ -1,0 +1,38 @@
+import { GluegunCommand } from 'gluegun';
+import { GluegunToolboxExtended } from '../extensions/extensions';
+import { checkCommandHelp } from '../scripts/help';
+
+/**
+ * This is the command that runs by default if no other commands match.
+ * See: https://github.com/infinitered/gluegun/blob/master/docs/runtime.md#defaultcommand
+ */
+const command: GluegunCommand = {
+  name: 'airfoil',
+  run: async (toolbox: GluegunToolboxExtended) => {
+    checkCommandHelp(toolbox);
+    const { print, meta, parameters } = toolbox;
+
+    const isRequestingVersion = Boolean(parameters.options.version);
+    if (isRequestingVersion) {
+      print.info(meta.version());
+      process.exit(0);
+    }
+
+    const composedParameters = parameters.array ? parameters.array.join(' ') : '';
+    const composedCommand = `airfoil ${composedParameters}`;
+
+    if (!composedParameters) {
+      print.error(
+        `No command specified for \`airfoil\`. Run \`airfoil --help\` for list of available commands.`,
+      );
+      process.exit(1);
+    }
+
+    print.error(
+      `\`${composedCommand}\` is not a valid command. Run \`airfoil --help\` for list of available commands.`,
+    );
+    process.exit(1);
+  },
+};
+
+module.exports = command;

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -13,7 +13,7 @@ import { getProjectName } from '../utils/meta';
 import { generatePassword } from '../utils/password';
 import { addTemplateAndPromptIfExisting } from '../utils/content';
 import { checkCommandHelp } from '../scripts/help';
-import { HELP_DESCRIPTION_CMD_ADD } from '../constants';
+import { HELP_DESCRIPTION_CMD_ADD } from '../help-descriptions/cmd-add';
 import { addAppIcon } from '../scripts/addAppIcon';
 
 const { padEnd, kebabCase } = _;

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -4,7 +4,7 @@ import { convertSvg } from '../scripts/convertSvg';
 import { interfaceHelpers } from '../utils/interface';
 import { validations } from '../utils/validations';
 import { checkCommandHelp } from '../scripts/help';
-import { HELP_DESCRIPTION_CMD_CONVERT } from '../constants';
+import { HELP_DESCRIPTION_CMD_CONVERT } from '../help-descriptions/cmd-convert';
 
 const TYPE_SVG = 'svg';
 const VALID_TYPES = [TYPE_SVG];

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -5,8 +5,8 @@ import {
   questionFileCategory,
   questionFileName,
   questionTakenFileName,
-  HELP_DESCRIPTION_CMD_CREATE,
 } from '../constants';
+import { HELP_DESCRIPTION_CMD_CREATE } from '../help-descriptions/cmd-create';
 import { interfaceHelpers } from '../utils/interface';
 import { validations } from '../utils/validations';
 import { checkCommandHelp } from '../scripts/help';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,12 +1,7 @@
 import { GluegunCommand } from 'gluegun';
 import { print } from 'gluegun/print';
-import {
-  Choice,
-  questionProjectName,
-  questionProjectType,
-  Template,
-  HELP_DESCRIPTION_CMD_INIT,
-} from '../constants';
+import { Choice, questionProjectName, questionProjectType, Template } from '../constants';
+import { HELP_DESCRIPTION_CMD_INIT } from '../help-descriptions/cmd-init';
 import { GluegunToolboxExtended } from '../extensions/extensions';
 import { checkCommandHelp } from '../scripts/help';
 import {

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -2,7 +2,7 @@ import { GluegunCommand } from 'gluegun';
 import { GluegunToolboxExtended } from '../extensions/extensions';
 import { interfaceHelpers } from '../utils/interface';
 import { validations } from '../utils/validations';
-import { HELP_DESCRIPTION_CMD_VERSION } from '../constants';
+import { HELP_DESCRIPTION_CMD_VERSION } from '../help-descriptions/cmd-version';
 import { checkCommandHelp } from '../scripts/help';
 
 const VERSION_TYPE_MAJOR = 'major';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -76,23 +76,7 @@ export const questionTakenFileName = {
     "Looks like there's already a file with that name. What would you like to name your file?",
 };
 
-// ------------------------
-// ----- DESCRIPTIONS -----
-// ------------------------
-export const HELP_DESCRIPTION_CMD_ADD =
-  '\nairfoil add [env | appcenter | adr | keystore]\n\nUsage:\n\nairfoil add env # if args omitted -> prompts to get ENV key, value\nairfoil add env MY_VAR=mydatahere\nairfoil add appcenter # follow prompts\nairfoil add adr # follow prompts\nairfoil add adr "Choose Cognito for Auth" # specify ADR title as arg1\nairfoil add keystore\n\nFor more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/add';
-
-export const HELP_DESCRIPTION_CMD_CONVERT =
-  '\nairfoil convert [svg]\n\nUsage:\n\nairfoil convert svg\nairfoil convert svg --cleanup # to remove app/assets/svg after successful conversion\n\nConverts .svg files to .tsx files for use in React Native. For more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/convert';
-
-export const HELP_DESCRIPTION_CMD_CREATE =
-  '\nairfoil [create | c]\n\nUsage:\n\nairfoil create # guides you through a quick wizard\nairfoil create component [ComponentName] [-f folderName]\nairfoil create hook [useHookName] [-f folderName]\n\nCreates a file and places it in the correct directory. Currently supported options:\n- component\n- hook. For more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/create';
-
-export const HELP_DESCRIPTION_CMD_INIT =
-  '\nairfoil [init | i | new] [nameOfProject]\n\nUsage:\n\nairfoil init myAwesomeApp\nairfoil init # prompts you for the <appName>\n\nInitializes a new React Native project. For more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/init';
-
-export const HELP_DESCRIPTION_CMD_VERSION =
-  '\nairfoil version [major | minor | patch]\n\nUsage:\n\nairfoil version patch # patch release (0.0.1 -> 0.0.2)\nairfoil version minor # minor release (0.0.2 -> 0.1.0)\nairfoil version major # major release (0.1.0 -> 1.0.0)\nairfoil version -u 4.5.6 # update exact version\n\nUpdates the version in package.json as well as ios/ and android/ directories. For more information, visit the official documentation:\nhttps://airfoil-docs.herokuapp.com/commands/version';
+export const DOCS_URL = 'https://airfoil.teamairship.com';
 
 // --------------------------
 // ----- APP ICON SIZES -----

--- a/src/help-descriptions/cmd-add.ts
+++ b/src/help-descriptions/cmd-add.ts
@@ -1,0 +1,18 @@
+import { DOCS_URL } from '../constants';
+
+export const HELP_DESCRIPTION_CMD_ADD = `airfoil add [env | appcenter | adr | keystore]
+
+Usage:
+
+airfoil add env # if args omitted -> prompts to get ENV key, value
+
+airfoil add env MY_VAR=mydatahere
+airfoil add appcenter # follow prompts
+airfoil add adr # follow prompts
+airfoil add adr "Choose Cognito for Auth" # specify ADR title as arg1
+airfoil add keystore
+
+For more information, visit the official documentation:
+${DOCS_URL}/commands/add
+
+`;

--- a/src/help-descriptions/cmd-convert.ts
+++ b/src/help-descriptions/cmd-convert.ts
@@ -1,0 +1,13 @@
+import { DOCS_URL } from '../constants';
+
+export const HELP_DESCRIPTION_CMD_CONVERT = `airfoil convert [svg]
+
+Usage:
+
+airfoil convert svg
+airfoil convert svg --cleanup # to remove app/assets/svg after successful conversion
+
+Converts .svg files to .tsx files for use in React Native. For more information, visit the official documentation:
+${DOCS_URL}/commands/convert
+
+`;

--- a/src/help-descriptions/cmd-create.ts
+++ b/src/help-descriptions/cmd-create.ts
@@ -1,0 +1,16 @@
+import { DOCS_URL } from '../constants';
+
+export const HELP_DESCRIPTION_CMD_CREATE = `airfoil [create | c]
+
+Usage:
+
+airfoil create # guides you through a quick wizard
+airfoil create component [ComponentName] [-f folderName]
+airfoil create hook [useHookName] [-f folderName]
+
+Creates a file and places it in the correct directory. Currently supported options:
+- component
+- hook. For more information, visit the official documentation:
+${DOCS_URL}/commands/create
+
+`;

--- a/src/help-descriptions/cmd-init.ts
+++ b/src/help-descriptions/cmd-init.ts
@@ -1,0 +1,14 @@
+import { DOCS_URL } from '../constants';
+
+export const HELP_DESCRIPTION_CMD_INIT = `
+airfoil [init | i | new] [nameOfProject]
+
+Usage:
+
+airfoil init myAwesomeApp
+airfoil init # prompts you for the <appName>
+
+Initializes a new React Native project. For more information, visit the official documentation:
+${DOCS_URL}/commands/init
+
+`;

--- a/src/help-descriptions/cmd-version.ts
+++ b/src/help-descriptions/cmd-version.ts
@@ -1,0 +1,15 @@
+import { DOCS_URL } from '../constants';
+
+export const HELP_DESCRIPTION_CMD_VERSION = `airfoil version [major | minor | patch]
+
+Usage:
+
+airfoil version patch # patch release (0.0.1 -> 0.0.2)
+airfoil version minor # minor release (0.0.2 -> 0.1.0)
+airfoil version major # major release (0.1.0 -> 1.0.0)
+airfoil version -u 4.5.6 # update exact version
+
+Updates the version in package.json as well as ios/ and android/ directories. For more information, visit the official documentation:
+${DOCS_URL}/commands/version
+
+`;

--- a/src/scripts/help.ts
+++ b/src/scripts/help.ts
@@ -1,4 +1,5 @@
 import { GluegunToolboxExtended } from '../extensions/extensions';
+import { DOCS_URL } from '../constants';
 
 export const OPTION_HELP = 'help';
 
@@ -9,6 +10,7 @@ export const checkCommandHelp = (toolbox: GluegunToolboxExtended) => {
 
   if (helpOption) {
     print.info(toolbox.command.description);
-    process.exit(1);
+    print.info(`View official documentation at ${DOCS_URL}`);
+    process.exit(0);
   }
 };


### PR DESCRIPTION
**Because:**
    
- `airfoil --version` was producing an error (https://github.com/teamairship/airfoil/issues/34)
- error message for wrong command left much to be desired

**This commit:**

- `airfoil --version` prints current version of airfoil
- `airfoil <INVALID_CMD>` prints a clear error message

**Screenshots:**

<img width="727" alt="airfoil-default-cmd" src="https://user-images.githubusercontent.com/5880655/129975387-52843920-3b6e-4f7e-bde1-2e2b59cd85fc.png">
