### PR TITLE
fix convert-svg cmd failing

### DIFF
--- a/src/scripts/convertSvg.ts
+++ b/src/scripts/convertSvg.ts
@@ -65,7 +65,7 @@ export const convertSvg = async (toolbox: GluegunToolboxExtended, cleanup = fals
     // add templates
     await addSvgrTemplateFile(toolbox);
     await addSvgoConfigFile(toolbox);
-    const action = `npx @svgr/cli --out-dir ${outPath} --ext tsx --template ${SVGR_TEMPLATE_DIR} --native --typescript --ignore-existing ${srcPath}`;
+    const action = `npx @svgr/cli@v5.5.0 --out-dir ${outPath} --ext tsx --template ${SVGR_TEMPLATE_DIR} --native --typescript --ignore-existing ${srcPath}`;
     // capture the stdout of the above command, which prints each converted file on a new line
     results = await cmd(action);
     // remove temp templates / config files


### PR DESCRIPTION
Because:

- @svgr/cli made breaking changes to the way svgr templates should be formatted in v6.0.0

This commit:

- Applies a quick fix by specifying the exact version of @svgr/cli to use in the convert-svg command

Notes:

- See: https://github.com/gregberge/svgr/releases/tag/v6.0.0
- See: https://react-svgr.com/docs/custom-templates/#custom-component-template